### PR TITLE
Use os node property and not os_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.11.0 (XXXX 2023)
+  - Use the `os` Node property to match other plugins
+
 v4.10.0 (September 2023)
   - Update gemspec links
 

--- a/lib/dradis/plugins/metasploit/gem_version.rb
+++ b/lib/dradis/plugins/metasploit/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 4
         MINOR = 10
-        TINY = 0
+        TINY = 1
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/dradis/plugins/metasploit/importer.rb
+++ b/lib/dradis/plugins/metasploit/importer.rb
@@ -68,7 +68,7 @@ module Dradis::Plugins::Metasploit
         end
 
         if os_name = xml_host.at_xpath('os-name')
-          host_node.set_property(:os_name, os_name.text)
+          host_node.set_property(:os, os_name.text)
         end
 
         # Service-related properties


### PR DESCRIPTION
### Summary

All of the other tools that define an OS Node Property use `os`. Metasploit was using `os_name` which meant that it could not be easily combined with other tools to export the OS data into a report. This PR moves from `os_name` to `os` for the Node property so that tools can be easily combined moving forward. 

### Copyright assignment

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.
