### PR TITLE
Move default mappings from files to service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.12.0 (Mmmm 2024)
+  - Migrate integration to use Mappings Manager
+
 v4.11.0 (January 2024)
   - No changes
 

--- a/lib/dradis/plugins/metasploit.rb
+++ b/lib/dradis/plugins/metasploit.rb
@@ -7,5 +7,6 @@ end
 
 require 'dradis/plugins/metasploit/engine'
 require 'dradis/plugins/metasploit/field_processor'
+require 'dradis/plugins/metasploit/mapping'
 require 'dradis/plugins/metasploit/importer'
 require 'dradis/plugins/metasploit/version'

--- a/lib/dradis/plugins/metasploit/mapping.rb
+++ b/lib/dradis/plugins/metasploit/mapping.rb
@@ -1,13 +1,11 @@
 module Dradis::Plugins::Metasploit
   module Mapping
-    def self.default_mapping
-      {
-        'host_note' => {
-          'Title' => 'Note {{ metasploit[host_note.id] }}',
-          'Type' => '{{ metasploit[host_note.ntype] }}',
-          'Data' => '{{ metasploit[host_note.data] }}'
-        }
+    DEFAULT_MAPPING = {
+      host_note: {
+        'Title' => 'Note {{ metasploit[host_note.id] }}',
+        'Type' => '{{ metasploit[host_note.ntype] }}',
+        'Data' => '{{ metasploit[host_note.data] }}'
       }
-    end
+    }.freeze
   end
 end

--- a/lib/dradis/plugins/metasploit/mapping.rb
+++ b/lib/dradis/plugins/metasploit/mapping.rb
@@ -1,6 +1,13 @@
 module Dradis::Plugins::Metasploit
   module Mapping
     def self.default_mapping
+      {
+        'host_note' => {
+          'Title' => 'Note {{ metasploit[host_note.id] }}',
+          'Type' => '{{ metasploit[host_note.ntype] }}',
+          'Data' => '{{ metasploit[host_note.data] }}'
+        }
+      }
     end
   end
 end

--- a/lib/dradis/plugins/metasploit/mapping.rb
+++ b/lib/dradis/plugins/metasploit/mapping.rb
@@ -1,0 +1,6 @@
+module Dradis::Plugins::Metasploit
+  module Mapping
+    def self.default_mapping
+    end
+  end
+end

--- a/templates/host_note.template
+++ b/templates/host_note.template
@@ -1,8 +1,0 @@
-#[Title]#
-Note %host_note.id%
-
-#[Type]#
-%host_note.ntype%
-
-#[Data]#
-%host_note.data%


### PR DESCRIPTION
### Summary

This PR adds `mapping_service.rb` with the default mappings moved over from the `.template` files

### Check List

- [x] Added a CHANGELOG entry
- [ ] Added specs
